### PR TITLE
Fix data definition casing

### DIFF
--- a/lib/scenic/adapters/oracle_enhanced/views.rb
+++ b/lib/scenic/adapters/oracle_enhanced/views.rb
@@ -45,8 +45,8 @@ module Scenic
 
           Scenic::View.new(
             name: namespaced_viewname,
-            definition: result['DEFINITION'].strip,
-            materialized: result['KIND'] == 'm'
+            definition: result['definition'].strip,
+            materialized: result['kind'] == 'm'
           )
         end
 


### PR DESCRIPTION
I'm not sure where it's happening, but the keys in the `result` hash
are in lowercase by the time they get to `to_scenic_view`.