### PR TITLE
Do not add a semicolon to DROP statements

### DIFF
--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -26,7 +26,7 @@ module Scenic
       end
 
       def drop_view(name)
-        execute "DROP VIEW #{quote_table_name(name)};"
+        execute "DROP VIEW #{quote_table_name(name)}"
       end
 
       def create_materialized_view(name, sql_definition)


### PR DESCRIPTION
This fixes a spot I missed last time around and removes a semicolon being added to DROP statements. Oracle doesn't like these semicolons.