### PR TITLE
Fix schema dumper

### DIFF
--- a/lib/scenic/adapters/oracle_enhanced/views.rb
+++ b/lib/scenic/adapters/oracle_enhanced/views.rb
@@ -34,12 +34,14 @@ module Scenic
                    owner      AS NAMESPACE,
                    query      AS DEFINITION
             FROM   all_mviews
+            WHERE owner = '#{@current_schema}'
             UNION ALL
             SELECT 'v'       AS KIND,
                    view_name AS VIEWNAME,
                    owner     AS NAMESPACE,
                    text      AS DEFINITION
             FROM   all_views
+            WHERE owner = '#{@current_schema}'
           SQL
         end
 
@@ -60,6 +62,17 @@ module Scenic
         end
 
         def oracle_identifier(name)
+          # We've copied this method from the PostgreSQL Scenic adapter.
+          # If the name makes it past the guard clause, the quoted Oracle identifiers
+          # will end up causing the OEA's `describe` method to generate
+          # invalid, improperly quoted object names.
+          #
+          # We don't know where this return value is used so, until we have
+          # an actual use case for a name that makes it past this guard, we
+          # are going to leave this as it is.
+          return name
+          return name if name =~ /^[a-zA-Z_][a-zA-Z0-9_]*$/
+
           connection.quote_column_name_or_expression(name)
         end
       end

--- a/lib/scenic/adapters/oracle_enhanced/views.rb
+++ b/lib/scenic/adapters/oracle_enhanced/views.rb
@@ -44,7 +44,7 @@ module Scenic
         end
 
         def to_scenic_view(result)
-          namespace, viewname = result[2], result[1]
+          namespace, viewname = result['namespace'], result['viewname']
 
           if namespace != 'SYS'
             namespaced_viewname = "#{oracle_identifier(namespace)}.#{oracle_identifier(viewname)}"

--- a/lib/scenic/adapters/oracle_enhanced/views.rb
+++ b/lib/scenic/adapters/oracle_enhanced/views.rb
@@ -70,7 +70,6 @@ module Scenic
           # We don't know where this return value is used so, until we have
           # an actual use case for a name that makes it past this guard, we
           # are going to leave this as it is.
-          return name
           return name if name =~ /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
           connection.quote_column_name_or_expression(name)

--- a/lib/scenic/adapters/oracle_enhanced/views.rb
+++ b/lib/scenic/adapters/oracle_enhanced/views.rb
@@ -4,6 +4,7 @@ module Scenic
       class Views
         def initialize(connection)
           @connection = connection
+          @current_schema = fetch_current_schema
         end
 
         def all
@@ -12,7 +13,15 @@ module Scenic
 
         private
 
-        attr_reader :connection
+        attr_reader :connection,
+                    :current_schema
+
+        def fetch_current_schema
+          ActiveRecord::Base.connection
+                            .execute("select sys_context('userenv', 'current_schema') from dual")
+                            .fetch
+                            .first
+        end
 
         def views_from_oracle
           # NOTE: Oracle cannot `UNION` on `LONG` fields,


### PR DESCRIPTION
This fixes the schema dumper by doing a couple of things:

- Making sure that only objects in the current schema are dumped
- Porting that guard clause from the PostgreSQL Scenic adapter to keep improperly quoted names from being passed down into the Oracle Enhanced adapter.

This resolves #6.