### PR TITLE
Make a couple of minor changes to the rails_sql_views portion of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,16 @@ Scenic.configure do |config|
 end
 ```
 
-## Migration
+## Switching from rails_sql_views to Scenic
 
 In Oracle 12, replacing a view has issues when the view refers to objects outside its own schema; use update_view, which will drop and create. The replace_view method can still be used for views referring to objects in their own schema.
 
-1. Run
-```sh
-bundle exec rails g scenic:view <full_view_name>
-```
- (if you use a prefix for the view, include it).
+1. Run `bundle exec rails g scenic:view <full_view_name>` (if you use a prefix for the view, include it).
 1. Move the view's SQL definition from the original migration into the newly-created file in db/views.
 1. In the original migration, delete any drop_view call.
 1. Copy the create_view or update_view line from the scenic migration and substitute it for the old create_view method and block.
 1. Delete the scenic migration file
-1. For the down method, copy the update_view line into the down (replacing any drop_ and create_view methods) and make the version: argument to the same number as the revert_to_version: argument (e.g. update_view :complex_data_view, version: 2, revert_to_version: 1 becomes `update_view :complex_data_view, version: 1, revert_to_version: 1`)
+1. For the down method, copy the update_view line into the down (replacing any drop_ and create_view methods) and make the version: argument to the same number as the revert_to_version: argument (e.g. `update_view :complex_data_view, version: 2, revert_to_version: 1` becomes `update_view :complex_data_view, version: 1, revert_to_version: 1`)
 
 ## Development
 


### PR DESCRIPTION
@talbutt, can you take a look at this PR and let me know what you think? There are just a few small changes to the README that I hope are sensible.

1. Change the header to remove the word "migration" since that's overloaded in this context
2. Make some minor formatting changes