### PR TITLE
WIP: Add Primary Key migration helper

### DIFF
--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -59,12 +59,13 @@ module Scenic
       def create_pk_for_view(object:, key: 'id')
         key_name = [object.to_s.split('.').last, key.to_s, 'pk'].join('_')
         suppress_messages do
-          execute <<-SQL
-          ALTER VIEW #{object} ADD CONSTRAINT #{key_name} PRIMARY KEY (#{key}) DISABLE
-          SQL
+          say_with_time do
+            execute <<-SQL
+            ALTER VIEW #{object} ADD CONSTRAINT #{key_name} PRIMARY KEY (#{key}) DISABLE
+            SQL
+            "Primary key #{key_name} created for #{object}."
+          end
         end
-
-        say 'Primary key created.', true
       end
 
       private

--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -58,13 +58,13 @@ module Scenic
       
       def create_pk_for_view(object:, key: 'id')
         key_name = [object.to_s.split('.').last, key.to_s, 'pk'].join('_')
-        suppress_messages do
-          say_with_time do
+        say_with_time do
+          suppress_messages do
             execute <<-SQL
             ALTER VIEW #{object} ADD CONSTRAINT #{key_name} PRIMARY KEY (#{key}) DISABLE
             SQL
-            "Primary key #{key_name} created for #{object}."
           end
+          "Primary key #{key_name} created for #{object}."
         end
       end
 

--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -57,7 +57,7 @@ module Scenic
       end
       
       def create_pk_for_view(object:, key: 'id')
-        key_name = [object.to_s.split('.').last, key, 'pk'].join('_')
+        key_name = [object.to_s.split('.').last, key.to_s, 'pk'].join('_')
         suppress_messages do
           execute <<-SQL
           ALTER VIEW #{object} ADD CONSTRAINT #{key_name} PRIMARY KEY (#{key}) DISABLE

--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -55,6 +55,17 @@ module Scenic
           execute "REFRESH MATERIALIZED VIEW #{quote_table_name(name)}"
         end
       end
+      
+      def create_pk_for_view(object:, key: 'id')
+        key_name = [object.to_s.split('.').last, key, 'pk'].join('_')
+        suppress_messages do
+          execute <<-SQL
+          ALTER VIEW #{object} ADD CONSTRAINT #{key_name} PRIMARY KEY (#{key}) DISABLE
+          SQL
+        end
+
+        say 'Primary key created.', true
+      end
 
       private
 


### PR DESCRIPTION
Views can have primary keys (in Oracle, at least) and Rails will happily work with them so you don't need to add `self.primary_key = :non_traditional_key_name` to your models. 

Adding this method here is a convenience and kind of a hack. If I could think of a way to inject the method from another gem, so it could be PMACS-only, I would feel better about it. I don't want this addition to torpedo our chances of the adapter being merged into the upstream project.

Another question for reviewers: I've used named keys in this method, but everything else uses positional keys. Should I follow the crowd?