### PR TITLE
Add no_data param to MV methods so they match up with Scenic

### DIFF
--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -35,7 +35,7 @@ module Scenic
           CREATE MATERIALIZED VIEW #{quote_table_name(name)}
           #{'BUILD DEFERRED' if no_data}
           AS
-          #{sql_definition}"
+          #{sql_definition}
         SQL
       end
 

--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -33,8 +33,7 @@ module Scenic
       def create_materialized_view(name, sql_definition, no_data: false)
         execute <<~SQL
           CREATE MATERIALIZED VIEW #{quote_table_name(name)}
-          #{'BUILD DEFERRED' if no_data}
-          AS
+          #{"BUILD DEFERRED\n" if no_data}AS
           #{sql_definition}
         SQL
       end

--- a/lib/scenic/adapters/oracle_enhanced.rb
+++ b/lib/scenic/adapters/oracle_enhanced.rb
@@ -30,14 +30,19 @@ module Scenic
         execute "DROP VIEW #{quote_table_name(name)}"
       end
 
-      def create_materialized_view(name, sql_definition)
-        execute "CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS #{sql_definition}"
+      def create_materialized_view(name, sql_definition, no_data: false)
+        execute <<~SQL
+          CREATE MATERIALIZED VIEW #{quote_table_name(name)}
+          #{'BUILD DEFERRED' if no_data}
+          AS
+          #{sql_definition}"
+        SQL
       end
 
-      def update_materialized_view(name, sql_definition)
+      def update_materialized_view(name, sql_definition, no_data: false)
         # IndexReapplication.new(connection: connection).on(name) do
           drop_materialized_view(name)
-          create_materialized_view(name, sql_definition)
+          create_materialized_view(name, sql_definition, no_data: no_data)
         # end
       end
 


### PR DESCRIPTION
Fixes #18 

Hey everyone,
My team keeps monkey-patching this in our projects, and Tim rightly suggested that maybe it was time we just submit a PR, so here it is.

I took the discussion on the issue into account and set `BUILD DEFERRED` based on the `no_data` argument in case anyone needs that. I think I'm going to submit an issue to Scenic in the hopes that they'll open up ways to pass other options to the adapters though, since Oracle materialized views have [lots of other options](https://docs.oracle.com/cd/B28359_01/server.111/b28286/statements_6002.htm#i2145767) that we can't currently add through Scenic.